### PR TITLE
Feature/switch to GitHub container registry

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -34,7 +34,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.CR_PAT }}
           registry: ${{ env.GCR_HOSTNAME }}
-          repository: ${{ github.repository }}/slim
+          repository: ${{ github.repository }}
           tags: ${{ steps.craft_tag.outputs.image_tag }}
           build_args: BUILDKIT_INLINE_CACHE=1
           cache_froms: >

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -26,6 +26,7 @@ jobs:
           password: ${{ secrets.CR_PAT }}
           registry: ${{ env.GCR_HOSTNAME }}
           repository: ${{ github.repository }}
+          target: build
           tags: build
           build_args: BUILDKIT_INLINE_CACHE=1
           cache_froms: ${{ env.GCR_HOSTNAME }}/${{ github.repository }}:build

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -35,7 +35,7 @@ jobs:
           password: ${{ secrets.CR_PAT }}
           registry: ${{ env.GCR_HOSTNAME }}
           repository: ${{ github.repository }}
-          tags: ${{ steps.craft_tag.outputs.image_tag }}
+          tags: build
           build_args: BUILDKIT_INLINE_CACHE=1
           cache_froms: ${{ env.GCR_HOSTNAME }}/${{ github.repository }}:build
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -25,18 +25,33 @@ jobs:
           -e 's/\//-/g'
           -e 's/master/latest/'
 
-      - name: Build with cache
+      - name: Build the first stage (build environment)
         uses: docker/build-push-action@v1
         env:
           # use BuildKit to speed up builds and improve caching
           DOCKER_BUILDKIT: 1
         with:
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+          registry: ${{ env.GCR_HOSTNAME }}
+          repository: ${{ github.repository }}
+          tags: ${{ steps.craft_tag.outputs.image_tag }}
+          build_args: BUILDKIT_INLINE_CACHE=1
+          cache_froms: ${{ env.GCR_HOSTNAME }}/${{ github.repository }}:build
+
+      - name: Build the final product (live artifact)
+        uses: docker/build-push-action@v1
+        env:
+          # use BuildKit to speed up builds and improve caching
+          DOCKER_BUILDKIT: 1
+        with:
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
           registry: ${{ env.GCR_HOSTNAME }}
           repository: ${{ github.repository }}
           tags: ${{ steps.craft_tag.outputs.image_tag }}
           build_args: BUILDKIT_INLINE_CACHE=1
           cache_froms: >
+            ${{ env.GCR_HOSTNAME }}/${{ github.repository }}:build,
             ${{ env.GCR_HOSTNAME }}/${{ github.repository }}:latest,
             ${{ env.GCR_HOSTNAME }}/${{ github.repository }}:${{ steps.craft_tag.outputs.image_tag }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -16,11 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: pull the build stage
-        run: |
-          echo ${{ secrets.CR_PAT }} | docker login ${{ env.GCR_HOSTNAME }} -u ${{ github.repository_owner }} --password-stdin
-          docker pull ${{ env.GCR_HOSTNAME }}/${{ github.repository }}:build
-
       - name: Build the first stage (build environment)
         uses: docker/build-push-action@v1
         env:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,4 +1,4 @@
-# only run when we push changes to master or PRs
+# only run when we push changes to master or  PRs
 on:
   push:
     branches: [master]

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -30,6 +30,8 @@ jobs:
           tags: build
           build_args: BUILDKIT_INLINE_CACHE=1
           cache_froms: ${{ env.GCR_HOSTNAME }}/${{ github.repository }}:build
+          # we only want to push when we're not in a pull request
+          push: ${{ github.event_name != 'pull_request' }}
 
       - name: Build the final product (live artifact)
         uses: docker/build-push-action@v1

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: pull the build stage
         run: |
-          echo ${{ secrets.CR_PAT }} | docker login docker.pkg.github.com -u ${{ github.repository_owner }} --password-stdin
+          echo ${{ secrets.CR_PAT }} | docker login ${{ env.GCR_HOSTNAME }} -u ${{ github.repository_owner }} --password-stdin
           docker pull ${{ env.GCR_HOSTNAME }}/${{ github.repository }}:build
 
       - name: Build the first stage (build environment)

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,11 +21,13 @@ jobs:
     steps:
       # do the normal checkout when the event is push/pull_request
       - uses: actions/checkout@v2
-        if: github.event_name != "workflow_dispatch"
+        if: github.event_name != 'workflow_dispatch'
 
       # checkout the specified tag when the event is workflow_dispatch
       - uses: actions/checkout@v2
-        if: github.event_name == "workflow_dispatch"
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          ref: ${{ github.event.inputs.tag }}
 
       - name: Build and cache first build stage
         # update the first stage cache only when pushing to or tagging main

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,8 +1,11 @@
-# only run when we push changes to master or  PRs
+name: Build and publish container image
+
 on:
+  # run when tagging or pushing to master
   push:
     branches: [master]
     tags: ["*"]
+  # run on PRs against master
   pull_request:
     branches: [master]
   workflow_dispatch:
@@ -16,15 +19,15 @@ env:
   GCR_HOSTNAME: ghcr.io
 
 jobs:
-  build_with_action:
+  build_and_push:
     runs-on: ubuntu-latest
     steps:
-      # do the normal checkout when the event is push/pull_request
-      - uses: actions/checkout@v2
+      - name: Checkout the latest SHA for this branch
+        uses: actions/checkout@v2
         if: github.event_name != 'workflow_dispatch'
 
-      # checkout the specified tag when the event is workflow_dispatch
-      - uses: actions/checkout@v2
+      - name: Checkout the specified tag
+        uses: actions/checkout@v2
         if: github.event_name == 'workflow_dispatch'
         with:
           ref: ${{ github.event.inputs.tag }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: pull the build stage
         run: |
-          echo ${{ github.token }} | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+          echo ${{ secrets.CR_PAT }} | docker login docker.pkg.github.com -u ${{ github.repository_owner }} --password-stdin
           docker pull ${{ env.GCR_HOSTNAME }}/${{ github.repository }}:build
 
       - name: Build the first stage (build environment)

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,6 +5,11 @@ on:
     tags: ["*"]
   pull_request:
     branches: [master]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Build a container image for this GitHub tag
+        required: true
 
 env:
   # GitHub Container Registry hostname
@@ -14,11 +19,17 @@ jobs:
   build_with_action:
     runs-on: ubuntu-latest
     steps:
+      # do the normal checkout when the event is push/pull_request
       - uses: actions/checkout@v2
+        if: github.event_name != "workflow_dispatch"
+
+      # checkout the specified tag when the event is workflow_dispatch
+      - uses: actions/checkout@v2
+        if: github.event_name == "workflow_dispatch"
 
       - name: Build and cache first build stage
         # update the first stage cache only when pushing to or tagging main
-        if: ${{ github.event_name != 'pull_request' }}
+        if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v1
         env:
           # use BuildKit to speed up builds and improve caching

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -16,7 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Build the first stage (build environment)
+      - name: Build and cache first stage (build environment)
+        # update the first stage cache only when pushing to or tagging main
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/build-push-action@v1
         env:
           # use BuildKit to speed up builds and improve caching
@@ -30,8 +32,6 @@ jobs:
           tags: build
           build_args: BUILDKIT_INLINE_CACHE=1
           cache_froms: ${{ env.GCR_HOSTNAME }}/${{ github.repository }}:build
-          # we only want to push when we're not in a pull request
-          push: ${{ github.event_name != 'pull_request' }}
 
       - name: Build the final product (live artifact)
         uses: docker/build-push-action@v1

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -33,10 +33,10 @@ jobs:
         with:
           username: ${{ github.actor }}
           password: ${{ secrets.CR_PAT }}
-          registry: ${{ env.GPR_HOSTNAME }}
+          registry: ${{ env.GCR_HOSTNAME }}
           repository: ${{ github.repository }}/slim
           tags: ${{ steps.craft_tag.outputs.image_tag }}
           build_args: BUILDKIT_INLINE_CACHE=1
           cache_froms: >
-            ${{ env.GPR_HOSTNAME }}/${{ github.repository }}:latest,
-            ${{ env.GPR_HOSTNAME }}/${{ github.repository }}:${{ steps.craft_tag.outputs.image_tag }}
+            ${{ env.GCR_HOSTNAME }}/${{ github.repository }}:latest,
+            ${{ env.GCR_HOSTNAME }}/${{ github.repository }}:${{ steps.craft_tag.outputs.image_tag }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -16,15 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Craft a valid tag for this build
-        id: craft_tag
-        run: >
-          echo -n "::set-output name=image_tag::";
-          echo ${{ github.ref }}
-          | sed -E -e 's/refs\/(heads|tags)?\/?//'
-          -e 's/\//-/g'
-          -e 's/master/latest/'
-
       - name: Build the first stage (build environment)
         uses: docker/build-push-action@v1
         env:
@@ -49,9 +40,8 @@ jobs:
           password: ${{ secrets.CR_PAT }}
           registry: ${{ env.GCR_HOSTNAME }}
           repository: ${{ github.repository }}
-          tags: ${{ steps.craft_tag.outputs.image_tag }}
+          tag_with_ref: true
           build_args: BUILDKIT_INLINE_CACHE=1
           cache_froms: >
             ${{ env.GCR_HOSTNAME }}/${{ github.repository }}:build,
-            ${{ env.GCR_HOSTNAME }}/${{ github.repository }}:latest,
-            ${{ env.GCR_HOSTNAME }}/${{ github.repository }}:${{ steps.craft_tag.outputs.image_tag }}
+            ${{ env.GCR_HOSTNAME }}/${{ github.repository }}:latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -7,8 +7,8 @@ on:
     branches: [master]
 
 env:
-  # GitHub Packages docker registry hostname
-  GPR_HOSTNAME: docker.pkg.github.com
+  # GitHub Container Registry hostname
+  GCR_HOSTNAME: ghcr.io
 
 jobs:
   build_with_action:
@@ -25,31 +25,6 @@ jobs:
           -e 's/\//-/g'
           -e 's/master/latest/'
 
-      - name: Check for an existing build for this ref
-        id: image_check
-        env:
-          URL: https://${{ env.GPR_HOSTNAME }}/v2/${{ github.repository }}/slim/manifests/${{ steps.craft_tag.outputs.image_tag }}
-          CREDS: ${{ github.actor }}:${{ github.token }}
-        run: |
-          echo -n "::set-output name=status_code::"
-          curl -o /dev/null -s -w '%{http_code}\n' -X GET $URL -u $CREDS
-
-      # this step compensates for a limitation of BuildKit + GPR
-      # https://github.com/containerd/containerd/issues/3291
-      - name: Pull an image to use for cache
-        run: |
-          # do we already have this tag in the repo? then pull it
-          if [[ "${{ steps.image_check.outputs.status_code }}" == "200" ]]; then
-            pull_tag=${{ steps.craft_tag.outputs.image_tag }}
-
-          # otherwise pull latest
-          else
-            pull_tag=latest
-          fi
-
-          echo ${{ github.token }} | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-          docker pull ${{ env.GPR_HOSTNAME }}/${{ github.repository }}/slim:$pull_tag
-
       - name: Build with cache
         uses: docker/build-push-action@v1
         env:
@@ -57,11 +32,11 @@ jobs:
           DOCKER_BUILDKIT: 1
         with:
           username: ${{ github.actor }}
-          password: ${{ github.token }}
+          password: ${{ secrets.CR_PAT }}
           registry: ${{ env.GPR_HOSTNAME }}
           repository: ${{ github.repository }}/slim
           tags: ${{ steps.craft_tag.outputs.image_tag }}
           build_args: BUILDKIT_INLINE_CACHE=1
           cache_froms: >
-            ${{ env.GPR_HOSTNAME }}/${{ github.repository }}/slim:latest,
-            ${{ env.GPR_HOSTNAME }}/${{ github.repository }}/slim:${{ steps.craft_tag.outputs.image_tag }}
+            ${{ env.GPR_HOSTNAME }}/${{ github.repository }}:latest,
+            ${{ env.GPR_HOSTNAME }}/${{ github.repository }}:${{ steps.craft_tag.outputs.image_tag }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Build and cache first stage (build environment)
+      - name: Build and cache first build stage
         # update the first stage cache only when pushing to or tagging main
         if: ${{ github.event_name != 'pull_request' }}
         uses: docker/build-push-action@v1
@@ -33,7 +33,7 @@ jobs:
           build_args: BUILDKIT_INLINE_CACHE=1
           cache_froms: ${{ env.GCR_HOSTNAME }}/${{ github.repository }}:build
 
-      - name: Build the final product (live artifact)
+      - name: Build the container image
         uses: docker/build-push-action@v1
         env:
           # use BuildKit to speed up builds and improve caching

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -16,6 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: pull the build stage
+        run: |
+          echo ${{ github.token }} | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+          docker pull ${{ env.GCR_HOSTNAME }}/${{ github.repository }}:build
+
       - name: Build the first stage (build environment)
         uses: docker/build-push-action@v1
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY go.mod go.sum main.go ./
 COPY cmd ./cmd
 
 # build the executable (w/cache hints)
-RUN --mount=type=cache,target=/go/pkg/mod \
+RUN --mount=type=cache,target=$GOPATH/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:experimental
+
 FROM golang AS build
 
 ENV GO111MODULE=on
@@ -7,13 +9,10 @@ WORKDIR /app
 COPY go.mod go.sum main.go ./
 COPY cmd ./cmd
 
-# fetch deps separately (for layer caching)
-RUN go mod download
-
-
-# build the executable
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build
-
+# build the executable (w/cache hints)
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build
 
 # create super thin container with the binary only
 FROM scratch

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.6.0
+VERSION=0.7.0
 PATH_BUILD=build/
 FILE_COMMAND=terragrunt-atlantis-config
 FILE_ARCH=darwin_amd64

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,9 @@ build: clean
     -build-ldflags "-X main.VERSION=$(VERSION)"
 
 test:
+	mkdir -p cmd/test_artifacts
 	go test -v ./...
+	rm -rf cmd/test_artifacts
 
 version:
 	@echo $(VERSION)

--- a/README.md
+++ b/README.md
@@ -154,6 +154,37 @@ jobs:
 
 You can customize the version and flags you typically pass to the `generate` command in those final two lines.
 
+## Separate workspace for parallel plan and apply
+Atlantis added support for running plan and apply parallel in [v0.13.0](https://github.com/runatlantis/atlantis/releases/tag/v0.13.0).
+To use this feature, projects has to be separated in different workspaces,
+`createWorkspace` flag enables this by concatenating the project path as the
+name of the workspace, eg: project `${git_root}/stage/app/terragrunt.hcl` will
+have the name `stage_app` as workspace name. This flag needs to be used along with
+`parallel` to enable parallel plan and apply:
+
+```
+terragrunt-atlantis-config generate --output atlantis.yaml --ignore-parent-terragrunt --workflow terragrunt --autoplan=false --parallel=true --createWorkspace=true
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+  dir: stage/app
+  workflow: terragrunt
+  workspace: stage_app
+```
+
+---
+***NOTE:***
+
+Enable this feature may consume more resources like cpu, memory, network and disk,
+as multiple projects are being processed at the same time.
+
+---
+
 ## Contributing
 
 To test any changes you've made, run `make test`.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## What is this?
 
-[Atlantis](runatlantis.io) is an awesome tool for Terraform pull request automation. Each repo can have a YAML config file that defines Terraform module dependendcies, so that PRs that affect dependent modules will automatically generate `terraform plan`s for those modules.
+[Atlantis](runatlantis.io) is an awesome tool for Terraform pull request automation. Each repo can have a YAML config file that defines Terraform module dependencies, so that PRs that affect dependent modules will automatically generate `terraform plan`s for those modules.
 
 [Terragrunt](https://terragrunt.gruntwork.io) is a Terraform wrapper, which has the concept of dependencies built into its configuration.
 
@@ -148,42 +148,26 @@ jobs:
         id: atlantis_validator
         uses: transcend-io/terragrunt-atlantis-config-github-action@v0.0.3
         with:
-          version: v0.6.0
+          version: v0.7.0
           extra_args: '--autoplan --parallel=false
 ```
 
 You can customize the version and flags you typically pass to the `generate` command in those final two lines.
 
 ## Separate workspace for parallel plan and apply
+
 Atlantis added support for running plan and apply parallel in [v0.13.0](https://github.com/runatlantis/atlantis/releases/tag/v0.13.0).
-To use this feature, projects has to be separated in different workspaces,
-`createWorkspace` flag enables this by concatenating the project path as the
-name of the workspace, eg: project `${git_root}/stage/app/terragrunt.hcl` will
-have the name `stage_app` as workspace name. This flag needs to be used along with
-`parallel` to enable parallel plan and apply:
 
-```
-terragrunt-atlantis-config generate --output atlantis.yaml --ignore-parent-terragrunt --workflow terragrunt --autoplan=false --parallel=true --createWorkspace=true
-automerge: false
-parallel_apply: true
-parallel_plan: true
-projects:
-- autoplan:
-    enabled: false
-    when_modified:
-    - '*.hcl'
-  dir: stage/app
-  workflow: terragrunt
-  workspace: stage_app
+To use this feature, projects have to be separated in different workspaces, and the `create-workspace` flag enables this by concatenating the project path as the
+name of the workspace.
+
+As an example, project `${git_root}/stage/app/terragrunt.hcl` will have the name `stage_app` as workspace name. This flag should be used along with `parallel` to enable parallel plan and apply:
+
+```bash
+terragrunt-atlantis-config generate --output atlantis.yaml --parallel --create-workspace
 ```
 
----
-***NOTE:***
-
-Enable this feature may consume more resources like cpu, memory, network and disk,
-as multiple projects are being processed at the same time.
-
----
+Enabling this feature may consume more resources like cpu, memory, network, and disk, as each workspace will now be cloned separately by atlantis.
 
 ## Contributing
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -109,11 +109,6 @@ func getDependencies(path string) ([]string, error) {
 		return nil, nil
 	}
 
-	unusedVar := "foobar"
-	if unusedVar == "baz" {
-		log.Info("not possible")
-	}
-
 	decodeTypes := []config.PartialDecodeSectionType{
 		config.DependencyBlock,
 		config.DependenciesBlock,

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -109,6 +109,11 @@ func getDependencies(path string) ([]string, error) {
 		return nil, nil
 	}
 
+	unusedVar := "foobar"
+	if unusedVar == "baz" {
+		log.Info("not possible")
+	}
+
 	decodeTypes := []config.PartialDecodeSectionType{
 		config.DependencyBlock,
 		config.DependenciesBlock,

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -324,7 +324,7 @@ func init() {
 	generateCmd.PersistentFlags().BoolVar(&autoPlan, "autoplan", false, "Enable auto plan. Default is disabled")
 	generateCmd.PersistentFlags().BoolVar(&ignoreParentTerragrunt, "ignore-parent-terragrunt", false, "Ignore parent terragrunt configs (those which don't reference a terraform module). Default is disabled")
 	generateCmd.PersistentFlags().BoolVar(&parallel, "parallel", true, "Enables plans and applys to happen in parallel. Default is enabled")
-	generateCmd.PersistentFlags().BoolVar(&createWorkspace, "createWorkspace", false, "Use different workspace for each project. Default is use default workspace")
+	generateCmd.PersistentFlags().BoolVar(&createWorkspace, "create-workspace", false, "Use different workspace for each project. Default is use default workspace")
 	generateCmd.PersistentFlags().StringVar(&defaultWorkflow, "workflow", "", "Name of the workflow to be customized in the atlantis server. Default is to not set")
 	generateCmd.PersistentFlags().StringVar(&outputPath, "output", "", "Path of the file where configuration will be generated. Default is not to write to file")
 	generateCmd.PersistentFlags().StringVar(&gitRoot, "root", pwd, "Path to the root directory of the github repo you want to build config for. Default is current dir")

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -166,6 +166,6 @@ func TestWithWorkspaces(t *testing.T) {
 	runTest(t, filepath.Join("golden", "withWorkspace.yaml"), []string{
 		"--root",
 		filepath.Join("..", "test_examples", "basic_module"),
-		"--createWorkspace=true",
+		"--create-workspace",
 	})
 }

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -161,3 +161,11 @@ func TestUnparseableParent(t *testing.T) {
 		"--ignore-parent-terragrunt",
 	})
 }
+
+func TestWithWorkspaces(t *testing.T) {
+	runTest(t, filepath.Join("golden", "withWorkspace.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "basic_module"),
+		"--createWorkspace=true",
+	})
+}

--- a/cmd/golden/withWorkspace.yaml
+++ b/cmd/golden/withWorkspace.yaml
@@ -1,0 +1,12 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: .
+  workspace: _
+version: 3

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import "github.com/transcend-io/terragrunt-atlantis-config/cmd"
 
 var (
-	VERSION = "0.6.0"
+	VERSION = "0.7.0"
 )
 
 func main() {


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- _[none]_

## Description

There are a number of issues with GitHub Packages Registry which are not present on GitHub Container Registry.  Most notably the required auth and lack of BuildKit support.  Let's switch to that!

### Important note!

This workflow requires a new secret to be added: `CR_PAT`.  This is an access token created by the repo owner with the following permissions:
* read:packages
* write:packages

## Security Implications

- Creating an access token with the above permissions means malicious workflows could exfiltrate data or write malicious data to your public repositories
    - Turn off secrets access for fork PRs
    - Reviewing workflows should now include security review
    - Ensure only the minimum required permissions are granted to the `CR_PAT` access token

## System Availability

- _[none]_
